### PR TITLE
Fix: Conversion to list.

### DIFF
--- a/buildSrc/src/main/java/cash/z/ecc/android/Dependencies.kt
+++ b/buildSrc/src/main/java/cash/z/ecc/android/Dependencies.kt
@@ -6,9 +6,10 @@ object Deps {
     const val kotlinVersion = "1.3.72"
     const val group = "cash.z.ecc.android"
     const val artifactName = "kotlin-bip39"
-    const val versionName = "1.0.0-beta08"
+    const val versionName = "1.0.0-beta09"
     const val description = "A concise implementation of BIP-0039 in Kotlin for Android."
     const val githubUrl = "https://github.com/zcash/kotlin-bip39"
+    const val publishingActive = false // set to true to activate bintrayUpload task
 
     object Kotlin : Version(kotlinVersion) {
         val STDLIB =        "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"

--- a/lib/publish.gradle
+++ b/lib/publish.gradle
@@ -78,7 +78,7 @@ bintray {
         userOrg = 'ecc-mobile'
         licenses = ['MIT']
         vcsUrl = Deps.githubUrl
-        dryRun = true
+        dryRun = !Deps.publishingActive
         version {
             name = Deps.versionName
             desc = Deps.description

--- a/lib/src/main/java/cash/z/ecc/android/bip39/Mnemonics.kt
+++ b/lib/src/main/java/cash/z/ecc/android/bip39/Mnemonics.kt
@@ -72,7 +72,7 @@ object Mnemonics {
                 var cursor = 0
                 chars.forEachIndexed { i, c ->
                     if (c == ' ' || i == chars.lastIndex) {
-                        add(chars.copyOfRange(cursor, if (chars[i].isWhitespace()) i else i - 1))
+                        add(chars.copyOfRange(cursor, if (chars[i].isWhitespace()) i else i + 1))
                         cursor = i + 1
                     }
                 }

--- a/lib/src/test/java/cash/z/ecc/android/bip39/MnemonicsTest.kt
+++ b/lib/src/test/java/cash/z/ecc/android/bip39/MnemonicsTest.kt
@@ -11,6 +11,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.data.forAll
 import io.kotest.data.row
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -81,8 +82,8 @@ class MnemonicsTest : BehaviorSpec({
                                     words.size shouldBe wordCount.count
                                 }
                                 Then("Each word is present in the original phrase") {
-                                    words.forEach {
-                                        phraseString shouldContain "$it"
+                                    phraseString.split(' ').let { correctWords ->
+                                        words.shouldContainAll(correctWords)
                                     }
                                 }
                             }


### PR DESCRIPTION
When converting from an array of characters into a list of words, there was an off-by-one error that was causing the words to display incorrectly. This issue did not effect the seed that was used it only impacted the display. The problem has been fixed and the tests updated to catch this type of problem in the future.

Addresses https://github.com/zcash/zcash-android-wallet/issues/163