### PR TITLE
resolve kotest failure

### DIFF
--- a/buildSrc/src/main/java/cash/z/ecc/android/Dependencies.kt
+++ b/buildSrc/src/main/java/cash/z/ecc/android/Dependencies.kt
@@ -3,13 +3,13 @@ package cash.z.ecc.android
 object Deps {
     // For use in the top-level build.gradle which gives an error when provided
     // `Deps.Kotlin.version` directly
-    const val kotlinVersion = "1.4.30"
+    const val kotlinVersion = "1.5.30"
 
     object Kotlin : Version(kotlinVersion) {
         val STDLIB =        "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
     }
 
-    object Kotest : Version("4.0.5") {
+    object Kotest : Version("4.6.1") {
         val RUNNER =        "io.kotest:kotest-runner-junit5-jvm:$version"
         val ASSERTIONS =    "io.kotest:kotest-assertions-core-jvm:$version"
         val PROPERTY =      "io.kotest:kotest-property-jvm:$version"


### PR DESCRIPTION
As indicated in https://github.com/kotest/kotest/issues/1600 the problem has already been fixed in newer versions.  This updates the library to fix the tests.